### PR TITLE
feat: closed beta gate — shared access code with cookie auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,7 @@ CRON_SECRET=your-cron-secret
 
 # Admin auth
 ADMIN_EMAIL=admin@yourdomain.com
+
+# Beta gate (optional — set to enable closed beta, remove to go public)
+BETA_ACCESS_CODE=
+BETA_FEEDBACK_URL=

--- a/src/app/beta/actions.ts
+++ b/src/app/beta/actions.ts
@@ -1,0 +1,24 @@
+'use server'
+
+import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
+import { BETA_ACCESS_CODE, BETA_COOKIE_NAME } from '@/lib/beta'
+
+export async function betaAccessAction(formData: FormData) {
+  const code = String(formData.get('code') ?? '').trim()
+
+  if (!code || code !== BETA_ACCESS_CODE) {
+    redirect('/beta?error=Invalid+access+code')
+  }
+
+  const store = await cookies()
+  store.set(BETA_COOKIE_NAME, code, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 60 * 60 * 24 * 30, // 30 days
+  })
+
+  redirect('/')
+}

--- a/src/app/beta/actions.ts
+++ b/src/app/beta/actions.ts
@@ -1,14 +1,23 @@
 'use server'
 
-import { cookies } from 'next/headers'
+import { cookies, headers } from 'next/headers'
 import { redirect } from 'next/navigation'
-import { BETA_ACCESS_CODE, BETA_COOKIE_NAME } from '@/lib/beta'
+import { BETA_ACCESS_CODE, BETA_COOKIE_NAME, safeCompare } from '@/lib/beta'
+import { isRateLimited, recordAttempt } from '@/lib/beta-rate-limit'
 
 export async function betaAccessAction(formData: FormData) {
+  const headerStore = await headers()
+  const ip = headerStore.get('x-forwarded-for') ?? 'unknown'
+
+  if (isRateLimited(ip)) {
+    redirect('/beta?error=rate_limited')
+  }
+
   const code = String(formData.get('code') ?? '').trim()
 
-  if (!code || code !== BETA_ACCESS_CODE) {
-    redirect('/beta?error=Invalid+access+code')
+  if (!code || !safeCompare(code, BETA_ACCESS_CODE)) {
+    recordAttempt(ip)
+    redirect('/beta?error=invalid_code')
   }
 
   const store = await cookies()

--- a/src/app/beta/page.tsx
+++ b/src/app/beta/page.tsx
@@ -1,0 +1,53 @@
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { betaAccessAction } from './actions'
+
+type BetaPageProps = {
+  searchParams: Promise<{ error?: string }>
+}
+
+export default async function BetaPage({ searchParams }: BetaPageProps) {
+  const params = await searchParams
+  const error = params.error ?? null
+
+  return (
+    <main className="min-h-screen bg-background px-6 py-16 text-foreground sm:px-10">
+      <section className="mx-auto w-full max-w-lg space-y-6 rounded-2xl border border-border bg-card p-6">
+        <header className="space-y-2">
+          <p className="text-sm font-medium tracking-[0.12em] text-muted-foreground uppercase">
+            Closed Beta
+          </p>
+          <h1 className="text-2xl font-semibold tracking-tight">Welcome to Stoogle</h1>
+          <p className="text-sm text-muted-foreground">
+            Enter the access code shared with you to continue.
+          </p>
+        </header>
+
+        {error ? (
+          <p className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
+            {error}
+          </p>
+        ) : null}
+
+        <form action={betaAccessAction} className="space-y-3">
+          <div className="space-y-1">
+            <label htmlFor="code" className="text-sm font-medium">
+              Access code
+            </label>
+            <Input
+              id="code"
+              name="code"
+              type="password"
+              autoComplete="off"
+              required
+              className="min-h-11"
+            />
+          </div>
+          <Button type="submit" className="min-h-11 w-full">
+            Enter Beta
+          </Button>
+        </form>
+      </section>
+    </main>
+  )
+}

--- a/src/app/beta/page.tsx
+++ b/src/app/beta/page.tsx
@@ -2,13 +2,18 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { betaAccessAction } from './actions'
 
+const ERROR_MESSAGES: Record<string, string> = {
+  invalid_code: 'Invalid access code. Please try again.',
+  rate_limited: 'Too many attempts. Please try again later.',
+}
+
 type BetaPageProps = {
   searchParams: Promise<{ error?: string }>
 }
 
 export default async function BetaPage({ searchParams }: BetaPageProps) {
   const params = await searchParams
-  const error = params.error ?? null
+  const error = params.error ? (ERROR_MESSAGES[params.error] ?? 'An error occurred.') : null
 
   return (
     <main className="min-h-screen bg-background px-6 py-16 text-foreground sm:px-10">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { BetaBanner } from "@/components/beta-banner";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -30,6 +31,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} overflow-x-hidden antialiased`}
       >
+        <BetaBanner />
         {children}
       </body>
     </html>

--- a/src/components/beta-banner.tsx
+++ b/src/components/beta-banner.tsx
@@ -1,0 +1,21 @@
+import { isBetaEnabled } from '@/lib/beta'
+
+export function BetaBanner() {
+  if (!isBetaEnabled) return null
+
+  const feedbackUrl = process.env.BETA_FEEDBACK_URL
+
+  return (
+    <div className="bg-primary px-4 py-2 text-center text-sm text-primary-foreground">
+      Stoogle closed beta
+      {feedbackUrl ? (
+        <>
+          {' — '}
+          <a href={feedbackUrl} target="_blank" rel="noopener noreferrer" className="underline underline-offset-2">
+            Share feedback
+          </a>
+        </>
+      ) : null}
+    </div>
+  )
+}

--- a/src/lib/beta-rate-limit.ts
+++ b/src/lib/beta-rate-limit.ts
@@ -1,0 +1,19 @@
+const MAX_ATTEMPTS = 5
+const WINDOW_MS = 15 * 60 * 1000 // 15 minutes
+
+const attempts = new Map<string, { count: number; resetAt: number }>()
+
+export function isRateLimited(ip: string, now = Date.now()): boolean {
+  const entry = attempts.get(ip)
+  if (!entry || now >= entry.resetAt) return false
+  return entry.count >= MAX_ATTEMPTS
+}
+
+export function recordAttempt(ip: string, now = Date.now()) {
+  const entry = attempts.get(ip)
+  if (!entry || now >= entry.resetAt) {
+    attempts.set(ip, { count: 1, resetAt: now + WINDOW_MS })
+  } else {
+    entry.count += 1
+  }
+}

--- a/src/lib/beta.ts
+++ b/src/lib/beta.ts
@@ -1,0 +1,3 @@
+export const BETA_COOKIE_NAME = 'stoogle_beta_access'
+export const BETA_ACCESS_CODE = process.env.BETA_ACCESS_CODE ?? ''
+export const isBetaEnabled = Boolean(BETA_ACCESS_CODE)

--- a/src/lib/beta.ts
+++ b/src/lib/beta.ts
@@ -1,3 +1,11 @@
+import { createHash, timingSafeEqual } from 'crypto'
+
 export const BETA_COOKIE_NAME = 'stoogle_beta_access'
 export const BETA_ACCESS_CODE = process.env.BETA_ACCESS_CODE ?? ''
 export const isBetaEnabled = Boolean(BETA_ACCESS_CODE)
+
+export function safeCompare(a: string, b: string): boolean {
+  const ha = createHash('sha256').update(a).digest()
+  const hb = createHash('sha256').update(b).digest()
+  return timingSafeEqual(ha, hb)
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { BETA_COOKIE_NAME } from '@/lib/beta'
+
+const BYPASS_PREFIXES = ['/beta', '/api/', '/admin', '/auth/', '/_next/', '/favicon.ico']
+
+export function middleware(request: NextRequest) {
+  const code = process.env.BETA_ACCESS_CODE ?? ''
+  if (!code) {
+    return NextResponse.next()
+  }
+
+  const { pathname } = request.nextUrl
+  if (BYPASS_PREFIXES.some((prefix) => pathname.startsWith(prefix))) {
+    return NextResponse.next()
+  }
+
+  const cookie = request.cookies.get(BETA_COOKIE_NAME)?.value
+  if (cookie === code) {
+    return NextResponse.next()
+  }
+
+  const betaUrl = new URL('/beta', request.url)
+  return NextResponse.redirect(betaUrl)
+}
+
+export const config = {
+  matcher: ['/((?!_next/static|_next/image|favicon\\.ico).*)'],
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { BETA_COOKIE_NAME } from '@/lib/beta'
+import { BETA_COOKIE_NAME, safeCompare } from '@/lib/beta'
 
 const BYPASS_PREFIXES = ['/beta', '/api/', '/admin', '/auth/', '/_next/', '/favicon.ico']
 
@@ -15,7 +15,7 @@ export function middleware(request: NextRequest) {
   }
 
   const cookie = request.cookies.get(BETA_COOKIE_NAME)?.value
-  if (cookie === code) {
+  if (cookie && safeCompare(cookie, code)) {
     return NextResponse.next()
   }
 

--- a/src/test/beta-gate.test.ts
+++ b/src/test/beta-gate.test.ts
@@ -67,6 +67,7 @@ describe('beta gate middleware', () => {
 describe('beta access action', () => {
   const mockSet = vi.fn()
   const mockRedirect = vi.fn()
+  const mockHeadersGet = vi.fn().mockReturnValue('127.0.0.1')
 
   beforeEach(() => {
     vi.resetModules()
@@ -74,6 +75,7 @@ describe('beta access action', () => {
 
     vi.doMock('next/headers', () => ({
       cookies: vi.fn().mockResolvedValue({ set: mockSet }),
+      headers: vi.fn().mockResolvedValue({ get: mockHeadersGet }),
     }))
 
     vi.doMock('next/navigation', () => ({
@@ -115,7 +117,7 @@ describe('beta access action', () => {
     form.set('code', 'wrong')
 
     await expect(betaAccessAction(form)).rejects.toThrow(
-      'NEXT_REDIRECT:/beta?error=Invalid+access+code'
+      'NEXT_REDIRECT:/beta?error=invalid_code'
     )
     expect(mockSet).not.toHaveBeenCalled()
   })
@@ -128,7 +130,42 @@ describe('beta access action', () => {
     form.set('code', '')
 
     await expect(betaAccessAction(form)).rejects.toThrow(
-      'NEXT_REDIRECT:/beta?error=Invalid+access+code'
+      'NEXT_REDIRECT:/beta?error=invalid_code'
     )
+  })
+})
+
+describe('beta rate limiting', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('allows attempts under the limit', async () => {
+    const { isRateLimited, recordAttempt } = await import('@/lib/beta-rate-limit')
+    const now = Date.now()
+    for (let i = 0; i < 4; i++) {
+      recordAttempt('1.2.3.4', now)
+    }
+    expect(isRateLimited('1.2.3.4', now)).toBe(false)
+  })
+
+  it('blocks after 5 failed attempts', async () => {
+    const { isRateLimited, recordAttempt } = await import('@/lib/beta-rate-limit')
+    const now = Date.now()
+    for (let i = 0; i < 5; i++) {
+      recordAttempt('1.2.3.4', now)
+    }
+    expect(isRateLimited('1.2.3.4', now)).toBe(true)
+  })
+
+  it('resets after the window expires', async () => {
+    const { isRateLimited, recordAttempt } = await import('@/lib/beta-rate-limit')
+    const now = Date.now()
+    for (let i = 0; i < 5; i++) {
+      recordAttempt('1.2.3.4', now)
+    }
+    expect(isRateLimited('1.2.3.4', now)).toBe(true)
+    const afterWindow = now + 15 * 60 * 1000
+    expect(isRateLimited('1.2.3.4', afterWindow)).toBe(false)
   })
 })

--- a/src/test/beta-gate.test.ts
+++ b/src/test/beta-gate.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+describe('beta gate middleware', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  async function importMiddleware() {
+    const mod = await import('@/middleware')
+    return mod.middleware
+  }
+
+  function makeRequest(path: string, cookie?: { name: string; value: string }) {
+    const url = `http://localhost:3000${path}`
+    const req = new NextRequest(url)
+    if (cookie) {
+      req.cookies.set(cookie.name, cookie.value)
+    }
+    return req
+  }
+
+  it('passes through when BETA_ACCESS_CODE is not set', async () => {
+    vi.stubEnv('BETA_ACCESS_CODE', '')
+    const middleware = await importMiddleware()
+    const res = middleware(makeRequest('/'))
+    expect(res.headers.get('location')).toBeNull()
+  })
+
+  it('redirects to /beta when code is set and no cookie present', async () => {
+    vi.stubEnv('BETA_ACCESS_CODE', 'secret123')
+    const middleware = await importMiddleware()
+    const res = middleware(makeRequest('/'))
+    expect(res.status).toBe(307)
+    expect(new URL(res.headers.get('location')!).pathname).toBe('/beta')
+  })
+
+  it('passes through when valid cookie is present', async () => {
+    vi.stubEnv('BETA_ACCESS_CODE', 'secret123')
+    const middleware = await importMiddleware()
+    const res = middleware(makeRequest('/', { name: 'stoogle_beta_access', value: 'secret123' }))
+    expect(res.headers.get('location')).toBeNull()
+  })
+
+  it('redirects when cookie value does not match code', async () => {
+    vi.stubEnv('BETA_ACCESS_CODE', 'secret123')
+    const middleware = await importMiddleware()
+    const res = middleware(makeRequest('/', { name: 'stoogle_beta_access', value: 'wrong' }))
+    expect(res.status).toBe(307)
+  })
+
+  it.each(['/beta', '/api/health', '/admin', '/auth/callback', '/_next/data', '/favicon.ico'])(
+    'bypasses %s even when beta is enabled',
+    async (path) => {
+      vi.stubEnv('BETA_ACCESS_CODE', 'secret123')
+      const middleware = await importMiddleware()
+      const res = middleware(makeRequest(path))
+      expect(res.headers.get('location')).toBeNull()
+    }
+  )
+})
+
+describe('beta access action', () => {
+  const mockSet = vi.fn()
+  const mockRedirect = vi.fn()
+
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+
+    vi.doMock('next/headers', () => ({
+      cookies: vi.fn().mockResolvedValue({ set: mockSet }),
+    }))
+
+    vi.doMock('next/navigation', () => ({
+      redirect: mockRedirect.mockImplementation((url: string) => {
+        throw new Error(`NEXT_REDIRECT:${url}`)
+      }),
+    }))
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('sets cookie and redirects to / on valid code', async () => {
+    vi.stubEnv('BETA_ACCESS_CODE', 'secret123')
+    const { betaAccessAction } = await import('@/app/beta/actions')
+
+    const form = new FormData()
+    form.set('code', 'secret123')
+
+    await expect(betaAccessAction(form)).rejects.toThrow('NEXT_REDIRECT:/')
+    expect(mockSet).toHaveBeenCalledWith(
+      'stoogle_beta_access',
+      'secret123',
+      expect.objectContaining({
+        httpOnly: true,
+        sameSite: 'lax',
+        path: '/',
+        maxAge: 60 * 60 * 24 * 30,
+      })
+    )
+  })
+
+  it('redirects with error on invalid code', async () => {
+    vi.stubEnv('BETA_ACCESS_CODE', 'secret123')
+    const { betaAccessAction } = await import('@/app/beta/actions')
+
+    const form = new FormData()
+    form.set('code', 'wrong')
+
+    await expect(betaAccessAction(form)).rejects.toThrow(
+      'NEXT_REDIRECT:/beta?error=Invalid+access+code'
+    )
+    expect(mockSet).not.toHaveBeenCalled()
+  })
+
+  it('redirects with error when code is empty', async () => {
+    vi.stubEnv('BETA_ACCESS_CODE', 'secret123')
+    const { betaAccessAction } = await import('@/app/beta/actions')
+
+    const form = new FormData()
+    form.set('code', '')
+
+    await expect(betaAccessAction(form)).rejects.toThrow(
+      'NEXT_REDIRECT:/beta?error=Invalid+access+code'
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- Adds a site-wide beta gate controlled by `BETA_ACCESS_CODE` env var — when set, unauthenticated visitors are redirected to `/beta` to enter a shared code
- Valid codes set an HTTP-only cookie granting 30-day access; removing the env var disables the gate entirely (zero-friction public transition)
- Includes feedback banner (`BETA_FEEDBACK_URL`) shown at top of page during beta period

## Files

| Action | File |
|--------|------|
| Create | `src/lib/beta.ts` — shared constants |
| Create | `src/middleware.ts` — route-level cookie gate with bypass list |
| Create | `src/app/beta/page.tsx` — access code entry page |
| Create | `src/app/beta/actions.ts` — server action (validate + set cookie) |
| Create | `src/components/beta-banner.tsx` — feedback banner |
| Create | `src/test/beta-gate.test.ts` — 13 tests |
| Modify | `src/app/layout.tsx` — add BetaBanner |
| Modify | `.env.example` — add BETA_ACCESS_CODE, BETA_FEEDBACK_URL |

## Test plan

- [x] 13 new tests pass (middleware redirects, bypass paths, cookie validation, server action)
- [x] Full suite: 287 tests passing across 39 files
- [x] `npm run build` succeeds — `/beta` route and middleware confirmed
- [x] `npm run lint` — 0 errors
- [ ] Manual: set `BETA_ACCESS_CODE` locally, verify gate appears and code grants access
- [ ] Manual: unset `BETA_ACCESS_CODE`, verify gate is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)